### PR TITLE
Bugfix/get it to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,16 @@ export class FooController implements interfaces.Controller {
 
 > Note: The controller should not use the hapijs reply method to control output, but rather it should return the result directly. Any errors should return a Boom error.
 
-### Step 2: Configure container and server
+The controller also needs to use constant types. Use `Symbol.for("Controller")` to register it as a controller.
+
+```ts
+const TYPES = {
+    Controller: Symbol.for("Controller")
+}
+```
+
+
+### Step 3: Configure container and server
 Configure the inversify container in your composition root as usual.
 
 Then, pass the container to the InversifyHapiServer constructor. This will allow it to register all controllers and their dependencies from your container and attach them to the hapi app.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 const TYPE = {
-    Controller: Symbol("Controller")
+    Controller: Symbol.for("Controller")
 };
 
 const METADATA_KEY = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,6 +53,8 @@ export class InversifyHapiServer {
         // register server-level middleware before anything else
         if (this.configFn) {
             this.configFn.apply(undefined, [this.app]);
+        } else {
+            this.app.connection({port: 8080});
         }
 
         this.registerControllers();


### PR DESCRIPTION
When trying to get inversify-hapijs to work `Symbol.for("Controller")` had to be used instead of `Symbol("Controller")`. 

This makes sense based on the documentatin on Symbol:

> The above syntax using the Symbol() function will not create a global symbol that is available in your whole codebase. To create symbols available across files and even across realms (each of which has its own global scope), use the methods Symbol.for

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol

I also found the documentation deceiving since you did have to put in `server.connection` in order to run it, so I added that command at build time if it's not configured.

Finally I also added documentation for adding the Type constant.


